### PR TITLE
proactively catch empty queue names

### DIFF
--- a/lib/iron_mq/queues.rb
+++ b/lib/iron_mq/queues.rb
@@ -8,6 +8,7 @@ module IronMQ
     def initialize(client, queue_name)
       @client = client
       @name = queue_name
+      raise ArgumentError, "Must provide a queue name" unless queue_name.is_a?(String) and queue_name.strip.length > 0
     end
 
     def info


### PR DESCRIPTION
otherwise you get a bizarre error "undefined method `encoding' for nil:NilClass"

![screen shot 2014-05-21 at 4 23 59 pm](https://cloud.githubusercontent.com/assets/15787/3045481/8ae6aab4-e11d-11e3-8108-097ad868b9c0.png)
