### PR TITLE
The queue name is mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ options = {
   }
 }
 
-ironmq.create_queue(options)
+ironmq.create_queue("my_queue_name", options)
 ```
 
 **Options:**


### PR DESCRIPTION
Without this change, I get an exception:

```
ERROR [2015-12-28 21:51:35.412] ConsoleLogger: Error message: wrong number of arguments calling `create_queue` (1 for 2)
ERROR [2015-12-28 21:51:35.413] ConsoleLogger: Stack trace:
ERROR [2015-12-28 21:51:35.413] ConsoleLogger:         /Volumes/extra/git/ecraft/uxfactory-hub/api/connections/connections.rb:37:in `create_queue'
ERROR [2015-12-28 21:51:35.413] ConsoleLogger:         /Volumes/extra/git/ecraft/uxfactory-hub/api/connections/connections.rb:13:in `put_with_0_params_private'
```