### PR TITLE
Corrected readme w.r.t. listing all queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ client = IronMQ::Client.new(project_id: "57a7b7b35e8e331d45000001", keystone: ke
 ### Get Queues List
 
 ```ruby
-list_queues = ironmq.queues # => [#<IronMQ::Queue:...>, ...]
+list_queues = ironmq.queues.list # => [#<IronMQ::Queue:...>, ...]
 ```
 
 --


### PR DESCRIPTION
`ironmq.queues` returns `ironmq`, it's necessary to add `.list` to get the list of queues.