### PR TITLE
Pin to version 2.9.4 of net-http-persistent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    iron_mq (5.0.2)
+    iron_mq (6.0.3)
       iron_core (>= 0.5.1)
 
 GEM
@@ -48,7 +48,7 @@ DEPENDENCIES
   iron_mq!
   iron_worker_ng
   minitest (>= 5.0)
-  net-http-persistent
+  net-http-persistent (= 2.9.4)
   parallel
   quicky
   rake

--- a/iron_mq.gemspec
+++ b/iron_mq.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "beanstalk-client"
   gem.add_development_dependency "uber_config"
   gem.add_development_dependency "typhoeus", ">= 0.5.4"
-  gem.add_development_dependency "net-http-persistent"
+  gem.add_development_dependency "net-http-persistent", "2.9.4"
   gem.add_development_dependency "quicky"
   gem.add_development_dependency "iron_worker_ng"
   gem.add_development_dependency "go"

--- a/lib/iron_mq/version.rb
+++ b/lib/iron_mq/version.rb
@@ -1,3 +1,3 @@
 module IronMQ
-  VERSION = "6.0.2"
+  VERSION = "6.0.3"
 end


### PR DESCRIPTION
Because net-http-persistent 3.x is not compatible with iron_mq_ruby. 
Fixes #111 .

Thanks @baversjo for reporting this.