### PR TITLE
removed dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ironmq = IronMQ::Client.new(host: 'mq-rackspace-ord.iron.io',
                             token:'MY_TOKEN',
                             project_id: 'MY_PROJECT_ID')
 ```
-The default host is AWS us-east-1 zone (mq-aws-us-east-1.iron.io). [See all available hosts/clouds/regions](http://dev.iron.io/mq/reference/clouds/).
+The default host is AWS us-east-1 zone (mq-aws-us-east-1.iron.io). 
 
 ### Keystone Authentication
 


### PR DESCRIPTION
the clouds page in the dev center was removed by me. I did this because it was about v2.

The change to this file was removing the link to that page